### PR TITLE
Produce both inline sourcemaps and a sourcemap for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "esbuild": ">=0.8.16"
   },
   "devDependencies": {
+    "@types/convert-source-map": "^1.5.1",
     "@types/jest": "^26.0.15",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "^14.14.10",
@@ -39,5 +40,8 @@
     "prettier": "^2.2.1",
     "tslib": "^2.0.3",
     "typescript": "^4.1.2"
+  },
+  "dependencies": {
+    "convert-source-map": "^1.7.0"
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -7,11 +7,11 @@ afterEach(() => {
 
 test("ts file", () => {
   const content = `
-    import names from './names'  
+    import names from './names'
 
     export function display() {
       return names
-    } 
+    }
   `;
 
   mockfs({
@@ -67,11 +67,11 @@ test("ts file", () => {
 
 test("with transformOptions", () => {
   const content = `
-    import names from './names'  
+    import names from './names'
 
     export function display() {
       return names
-    } 
+    }
   `;
 
   mockfs({
@@ -102,7 +102,48 @@ test("with transformOptions", () => {
     "
     `);
 
-  expect(output.map).toEqual("");
+  expect(output.map).toBeNull();
+});
+
+test("with sourcemaps", () => {
+  const content = `
+    import names from './names'
+
+    export function display() {
+      return names
+    }
+  `;
+
+  mockfs({
+    "./tests/index.spec.ts": content,
+  });
+
+  const output = process(content, "./tests/index.spec.ts", {
+    transform: [
+      [
+        "^.+\\.ts?$",
+        "./dist/esbuild-jest.js",
+        {
+          format: "esm",
+          sourcemap: true
+        },
+      ],
+    ],
+  });
+
+  expect(output.code).toMatchInlineSnapshot(`
+    "import names2 from \\"./names\\";
+    function display() {
+      return names2;
+    }
+    export {
+      display
+    };
+    //# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi90ZXN0cy9pbmRleC5zcGVjLnRzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJcbiAgICBpbXBvcnQgbmFtZXMgZnJvbSAnLi9uYW1lcydcblxuICAgIGV4cG9ydCBmdW5jdGlvbiBkaXNwbGF5KCkge1xuICAgICAgcmV0dXJuIG5hbWVzXG4gICAgfVxuICAiXSwKICAibWFwcGluZ3MiOiAiQUFDSTtBQUVPO0FBQ0wsU0FBTztBQUFBOyIsCiAgIm5hbWVzIjogW10KfQo=
+    "
+    `);
+
+  expect(output.map).toEqual({"version":3,"sources":["./tests/index.spec.ts"],"sourcesContent":["\n    import names from './names'\n\n    export function display() {\n      return names\n    }\n  "],"mappings":"AACI;AAEO;AACL,SAAO;AAAA;","names":[]});
 });
 
 test("load index.(x)", async () => {
@@ -111,7 +152,7 @@ test("load index.(x)", async () => {
     render() {
       return <div className="hehe">hello there!!!</div>
     }
-  }  
+  }
   `;
 
   const tests = `
@@ -167,5 +208,5 @@ test("load index.(x)", async () => {
     "
   `)
 
-  expect(output.map).toEqual("");
+  expect(output.map).toBeNull();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,6 +602,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/convert-source-map@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@types/convert-source-map/-/convert-source-map-1.5.1.tgz#d4d180dd6adc5cb68ad99bd56e03d637881f4616"
+  integrity sha512-laiDIXqqthjJlyAMYAXOtN3N8+UlbM+KvZi4BaY5ZOekmVkBs/UxfK5O0HWeJVG2eW8F+Mu2ww13fTX+kY1FlQ==
+
 "@types/estree@*":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"


### PR DESCRIPTION
This allows VSCode or other development tools to debug the produced source code just by reading the transformed contents, as well as Jest to produce its nice error assertion messages.

Fixes #9