### PR TITLE
Produce both inline sourcemaps and a sourcemap for jest with new esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/aelbore/esbuild-jest#readme",
   "peerDependencies": {
-    "esbuild": ">=0.8.16"
+    "esbuild": ">=0.8.31"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",
@@ -33,7 +33,7 @@
     "@types/node": "^14.14.10",
     "aria-build": "^0.6.1",
     "aria-fs": "^0.6.1",
-    "esbuild": "^0.8.16",
+    "esbuild": "^0.8.31",
     "jest": "^26.6.3",
     "mock-fs": "^4.13.0",
     "prettier": "^2.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Format, Loader, transformSync } from 'esbuild'
+import { Format, Loader, TransformOptions, transformSync } from 'esbuild'
 import path, { extname } from 'path'
 
 const getExt = (str: string) => {
@@ -41,8 +41,8 @@ export function process(content: string, filename: string, config: any) {
     ? options.loaders[ext]
     : extname(filename).slice(1) as Loader
 
-  const sourcemaps = options?.sourcemap 
-    ? { sourcemap: true, sourcefile: filename }
+  const sourcemaps: Partial<TransformOptions> = options?.sourcemap
+    ? { sourcemap: "both", sourcefile: filename }
     : {}
 
   const result = transformSync(content, {
@@ -59,6 +59,6 @@ export function process(content: string, filename: string, config: any) {
     map: result?.map ? {
       ...JSON.parse(result.map),
       sourcesContent: null,
-    }: ''
+    } : null
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,15 +35,14 @@ export interface Options {
 
 export function process(content: string, filename: string, config: any) {
   const options: Options = getOptions(config)
+  const enableSourcemaps =  typeof options?.sourcemap == 'undefined' || options?.sourcemap
 
   const ext = getExt(filename)
   const loader = options?.loaders && options?.loaders[ext] 
     ? options.loaders[ext]
     : extname(filename).slice(1) as Loader
 
-  const sourcemaps: Partial<TransformOptions> = options?.sourcemap
-    ? { sourcemap: "external", sourcefile: filename }
-    : {}
+  const sourcemaps: Partial<TransformOptions> = enableSourcemaps ? { sourcemap: "external", sourcefile: filename } : {}
 
   const result = transformSync(content, {
     loader,
@@ -54,19 +53,23 @@ export function process(content: string, filename: string, config: any) {
     ...sourcemaps
   })
 
-  const map = {
-    ...JSON.parse(result.map),
-    sourcesContent: null,
+  let { map, code } = result;
+  if (enableSourcemaps) {
+    map = {
+      ...JSON.parse(result.map),
+      sourcesContent: null,
+    }
+
+    // Append the inline sourcemap manually to ensure the "sourcesContent"
+    // is null. Otherwise, breakpoints won't pause within the actual source.
+    code = code +
+    '\n//# sourceMappingURL=data:application/json;base64,' +
+    Buffer.from(JSON.stringify(map)).toString('base64')
+  } else {
+    map = null
   }
 
-  // Append the inline sourcemap manually to ensure the "sourcesContent"
-  // is null. Otherwise, breakpoints won't pause within the actual source.
-  return {
-    code:
-      result.code +
-      '\n//# sourceMappingURL=data:application/json;base64,' +
-      Buffer.from(JSON.stringify(map)).toString('base64'),
-    map,
-  }
+
+  return { code, map }
 }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -7,11 +7,11 @@ afterEach(() => {
 
 test("ts file", () => {
   const content = `
-    import names from './names'  
+    import names from './names'
 
     export function display() {
       return names
-    } 
+    }
   `;
 
   mockfs({
@@ -57,9 +57,9 @@ test("ts file", () => {
     __export(exports, {
       display: () => display
     });
-    var names = __toModule(require(\\"./names\\"));
+    var import_names = __toModule(require(\\"./names\\"));
     function display() {
-      return names.default;
+      return import_names.default;
     }
     "
   `);
@@ -67,11 +67,11 @@ test("ts file", () => {
 
 test("with transformOptions", () => {
   const content = `
-    import names from './names'  
+    import names from './names'
 
     export function display() {
       return names
-    } 
+    }
   `;
 
   mockfs({
@@ -92,9 +92,9 @@ test("with transformOptions", () => {
   });
 
   expect(output.code).toMatchInlineSnapshot(`
-    "import names2 from \\"./names\\";
+    "import names from \\"./names\\";
     function display() {
-      return names2;
+      return names;
     }
     export {
       display
@@ -102,7 +102,48 @@ test("with transformOptions", () => {
     "
     `);
 
-  expect(output.map).toEqual("");
+  expect(output.map).toBeNull();
+});
+
+test("with sourcemaps", () => {
+  const content = `
+    import names from './names'
+
+    export function display() {
+      return names
+    }
+  `;
+
+  mockfs({
+    "./tests/index.spec.ts": content,
+  });
+
+  const output = process(content, "./tests/index.spec.ts", {
+    transform: [
+      [
+        "^.+\\.ts?$",
+        "./dist/esbuild-jest.js",
+        {
+          format: "esm",
+          sourcemap: true
+        },
+      ],
+    ],
+  });
+
+  expect(output.code).toMatchInlineSnapshot(`
+    "import names from \\"./names\\";
+    function display() {
+      return names;
+    }
+    export {
+      display
+    };
+    //# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi90ZXN0cy9pbmRleC5zcGVjLnRzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJcbiAgICBpbXBvcnQgbmFtZXMgZnJvbSAnLi9uYW1lcydcblxuICAgIGV4cG9ydCBmdW5jdGlvbiBkaXNwbGF5KCkge1xuICAgICAgcmV0dXJuIG5hbWVzXG4gICAgfVxuICAiXSwKICAibWFwcGluZ3MiOiAiQUFDSTtBQUVPO0FBQ0wsU0FBTztBQUFBOyIsCiAgIm5hbWVzIjogW10KfQo=
+    "
+    `);
+
+  expect(output.map).toEqual({"version":3,"sources":["./tests/index.spec.ts"],"sourcesContent":null,"mappings":"AACI;AAEO;AACL,SAAO;AAAA;","names":[]});
 });
 
 test("load index.(x)", async () => {
@@ -111,7 +152,7 @@ test("load index.(x)", async () => {
     render() {
       return <div className="hehe">hello there!!!</div>
     }
-  }  
+  }
   `;
 
   const tests = `
@@ -167,5 +208,5 @@ test("load index.(x)", async () => {
     "
   `)
 
-  expect(output.map).toEqual("");
+  expect(output.map).toBeNull();
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -12,6 +12,8 @@ test("ts file", () => {
     export function display() {
       return names
     }
+
+    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwic291cmNlc0NvbnRlbnQiOm51bGwsIm1hcHBpbmdzIjoiIiwibmFtZXMiOltdfQ==
   `;
 
   mockfs({
@@ -61,7 +63,8 @@ test("ts file", () => {
     function display() {
       return import_names.default;
     }
-    "
+
+    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4vdGVzdHMvaW5kZXguc3BlYy50cyJdLCJzb3VyY2VzQ29udGVudCI6bnVsbCwibWFwcGluZ3MiOiI7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBQUE7QUFBQTtBQUFBO0FBQ0ksbUJBQWtCO0FBRVg7QUFDTCxTQUFPO0FBQUE7IiwibmFtZXMiOltdfQ=="
   `);
 });
 
@@ -139,8 +142,8 @@ test("with sourcemaps", () => {
     export {
       display
     };
-    //# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi90ZXN0cy9pbmRleC5zcGVjLnRzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJcbiAgICBpbXBvcnQgbmFtZXMgZnJvbSAnLi9uYW1lcydcblxuICAgIGV4cG9ydCBmdW5jdGlvbiBkaXNwbGF5KCkge1xuICAgICAgcmV0dXJuIG5hbWVzXG4gICAgfVxuICAiXSwKICAibWFwcGluZ3MiOiAiQUFDSTtBQUVPO0FBQ0wsU0FBTztBQUFBOyIsCiAgIm5hbWVzIjogW10KfQo=
-    "
+
+    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4vdGVzdHMvaW5kZXguc3BlYy50cyJdLCJzb3VyY2VzQ29udGVudCI6bnVsbCwibWFwcGluZ3MiOiJBQUNJO0FBRU87QUFDTCxTQUFPO0FBQUE7IiwibmFtZXMiOltdfQ=="
     `);
 
   expect(output.map).toEqual({"version":3,"sources":["./tests/index.spec.ts"],"sourcesContent":null,"mappings":"AACI;AAEO;AACL,SAAO;AAAA;","names":[]});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,15 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-esbuild@^0.8.12, esbuild@^0.8.16:
+esbuild@^0.8.12:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.17.tgz#1c16c6d5988dcfdcf27a7e1612b7fd05e1477c54"
   integrity sha512-ReHap+Iyn5BQF0B8F3xrLwu+j57ri5uDUw2ej9XTPAuFDebYiWwRzBY4jhF610bklveXLbCGim/8/2wQKQlu1w==
+
+esbuild@^0.8.31:
+  version "0.8.31"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.31.tgz#c21e7adb3ad283c951a53de7ad64a5ae2df2ed34"
+  integrity sha512-7EIU0VdUxltwivjVezX3HgeNzeIVR1snkrAo57WdUnuBMykdzin5rTrxwCDM6xQqj0RL/HjOEm3wFr2ijHKeaA==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
esbuild v0.8.31 supports returning a sourcemap as well as adding it inline. We want an inline sourcemap to facilitate debugging transformed source from within an editor (like VSCode) as well as a returned sourcemap to pass into Jest for it's nice assertion messages.

https://github.com/aelbore/esbuild-jest/commit/37fbe818ba841e620ed465a7f0a4ec383008161a originally removed inline source maps which I think was for performance. If we're really sure that adding an inline source map causes a performance hit we could make this an option, but I think it'd be better to just emit debuggable code by default when sourcemaps are enabled. Sourcemaps are disabled by default when using `esbuild-jest`, which means jest assertion line numbers are wrong by default which seems a little wonky, but we could change that elsewhere. 

Fixes #9. 