### PR TITLE
fix: `spyOn` mocking issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const createTransformer = (options?: Options) => ({
     /// this will support the jest.mock
     /// https://github.com/aelbore/esbuild-jest/issues/12
     /// TODO: transform the jest.mock to a function using babel traverse/parse then hoist it
-    if (sources.code.indexOf("ock(") >= 0 || opts?.instrument) {
+    if (sources.code.indexOf("ock(") >= 0 || sources.code.indexOf("spyOn(") >= 0 || opts?.instrument) {
       const source = require('./transformer').babelTransform({
         sourceText: content,
         sourcePath: filename,

--- a/tests/react-ts-spy.spec.tsx
+++ b/tests/react-ts-spy.spec.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { render } from "react-dom";
+import { afterEach, beforeEach, expect, it, jest } from "@jest/globals";
+
+import App from '../examples/react-ts/App'
+
+let element: HTMLElement
+
+beforeEach(() => {
+  element = document.createElement("div");
+  document.body.appendChild(element);
+})
+
+afterEach(() => {
+  element.remove();
+})
+
+it("should render with jest.spyOn", () => {
+  jest.spyOn(React, 'useEffect');
+  render(<App />, element);
+  expect(element.innerHTML).toMatchInlineSnapshot(`"<div>hello world!</div>"`);
+});


### PR DESCRIPTION
If we don't have `jest.mock` in file, it does break when using `jest.spyOn`.

As an example, user might want to mock implementation of `useEffects` in react, to run this hook, but it threw error previously:

![image](https://user-images.githubusercontent.com/16621507/112301907-1d0ed000-8ca3-11eb-9dec-1455a0132b07.png)
