### PR TITLE
sourcemap setting getting passed to esbuild transform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const createTransformer = (options?: Options) => ({
       : loaders.includes(extName) ? extName: 'text'
     ) as Loader
     const sourcemaps: Partial<TransformOptions> = enableSourcemaps 
-      ? { sourcemap: true, sourcesContent: false, sourcefile: filename } 
+      ? { sourcemap: enableSourcemaps, sourcesContent: false, sourcefile: filename } 
       : {}
 
     /// this logic or code from 


### PR DESCRIPTION
A small change that makes sure that the source map option is actually getting passed to esbuild transform as it's described in jest transform options.

Although unsure 100% about the change as you have folks here `options` and `opts` in the same time and I'm not sure if it's a bug or not. And where is what.

Related #24