### PR TITLE
feat: add explicit option to disable/enable instrument

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ export interface Options {
   },
   target?: string
   format?: string
+  instrument?: boolean
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const createTransformer = (options?: Options) => ({
     /// this will support the jest.mock
     /// https://github.com/aelbore/esbuild-jest/issues/12
     /// TODO: transform the jest.mock to a function using babel traverse/parse then hoist it
-    if (sources.code.indexOf("ock(") >= 0 || opts?.instrument) {
+    if (options.instrument !== false && (sources.code.indexOf("ock(") >= 0 || opts?.instrument || options?.instrument)) {
       const source = require('./transformer').babelTransform({
         sourceText: content,
         sourcePath: filename,

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,4 +9,5 @@ export interface Options {
   },
   target?: string
   format?: string
+  instrument?: boolean
 }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -95,3 +95,32 @@ test('should not have sourcemap [default]', () => {
   const output = process('./examples/names-ts/index.ts', { sourcemap: false })
   expect(output.map).toBeNull()
 })
+
+test('should be able to disable instrument', () => {
+  const output = process('./examples/names-ts/index.spec.ts', { instrument: false })
+
+  expect(output.code).toMatchInlineSnapshot(`
+    \"import {expect} from \\"@jest/globals\\";
+    import {display} from \\"./index\\";
+    jest.mock(\\"./index\\", () => {
+      return {
+        display() {
+          return [\\"Joe\\"];
+        }
+      };
+    });
+    test(\\"should parse with [jest.mock]\\", () => {
+      expect(display()).toEqual([\\"Joe\\"]);
+    });
+
+    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4vZXhhbXBsZXMvbmFtZXMtdHMvaW5kZXguc3BlYy50cyJdLCJtYXBwaW5ncyI6IkFBQUE7QUFFQTtBQUVBLEtBQUssS0FBSyxXQUFXO0FBQ25CLFNBQU87QUFBQSxJQUNMO0FBQ0UsYUFBTyxDQUFFO0FBQUE7QUFBQTtBQUFBO0FBS2YsS0FBSyxpQ0FBaUM7QUFDcEMsU0FBTyxXQUFXLFFBQVEsQ0FBRTtBQUFBOyIsIm5hbWVzIjpbXSwic291cmNlc0NvbnRlbnQiOm51bGx9"
+  `)
+
+   expect(output.map).toEqual(      {
+    version: 3,
+    sources: [ './examples/names-ts/index.spec.ts' ],
+    mappings: 'AAAA;AAEA;AAEA,KAAK,KAAK,WAAW;AACnB,SAAO;AAAA,IACL;AACE,aAAO,CAAE;AAAA;AAAA;AAAA;AAKf,KAAK,iCAAiC;AACpC,SAAO,WAAW,QAAQ,CAAE;AAAA;',
+    names: [],
+    sourcesContent: null
+  })
+})


### PR DESCRIPTION
Had some code that I was looking to use this with, but it contained `block(`, which triggered the babel to run. Figured it'd be good to have a way to explicitly disable running the code through babel, so added `instrument` option to the config.