### PR TITLE
Fix loaders extension parsing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,19 +3,8 @@ import { Format, Loader, TransformOptions } from 'esbuild'
 
 const loaders = ['js', 'jsx', 'ts', 'tsx', 'json']
 
-const getExt = (str: string) => {
-  const basename = path.basename(str);
-  const firstDot = basename.indexOf('.');
-  const lastDot = basename.lastIndexOf('.');
-  const extname = path.extname(basename).replace(/(\.[a-z0-9]+).*/i, '$1');
-
-  if (firstDot === lastDot) return extname
-
-  return basename.slice(firstDot, lastDot) + extname
-}
-
 export const getEsbuildConfig = (options, filename) => {
-  const ext = getExt(filename),
+  const ext = path.extname(filename),
     extName = path.extname(filename).slice(1)
   const loader = (options?.loaders && options?.loaders[ext]
     ? options.loaders[ext]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
 import path from 'path' 
+import { Format, Loader, TransformOptions } from 'esbuild'
 
-export const loaders = ["js", "jsx", "ts", "tsx", "json"]
+const loaders = ['js', 'jsx', 'ts', 'tsx', 'json']
 
-export const getExt = (str: string) => {
+const getExt = (str: string) => {
   const basename = path.basename(str);
   const firstDot = basename.indexOf('.');
   const lastDot = basename.lastIndexOf('.');
@@ -11,4 +12,28 @@ export const getExt = (str: string) => {
   if (firstDot === lastDot) return extname
 
   return basename.slice(firstDot, lastDot) + extname
+}
+
+export const getEsbuildConfig = (options, filename) => {
+  const ext = getExt(filename),
+    extName = path.extname(filename).slice(1)
+  const loader = (options?.loaders && options?.loaders[ext]
+    ? options.loaders[ext]
+    : loaders.includes(extName)
+    ? extName
+    : 'text') as Loader
+
+  const enableSourcemaps = options?.sourcemap || false
+  const sourcemaps: Partial<TransformOptions> = enableSourcemaps
+    ? { sourcemap: true, sourcesContent: false, sourcefile: filename }
+    : {}
+
+  return {
+    loader,
+    format: (options?.format as Format) || 'cjs',
+    target: options?.target || 'es2018',
+    ...(options?.jsxFactory ? { jsxFactory: options.jsxFactory } : {}),
+    ...(options?.jsxFragment ? { jsxFragment: options.jsxFragment } : {}),
+    ...sourcemaps,
+  }
 }

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -28,7 +28,7 @@ describe('getEsbuildConfig', () => {
       });
     });
 
-    xtest('.js loader returns correct config with compound extension', () => {
+    test('.js loader returns correct config with compound extension', () => {
       const config = getEsbuildConfig(
         { loaders: { '.js': 'jsx' } },
         'filename.test.js'

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,0 +1,44 @@
+import { getEsbuildConfig } from '../src/utils';
+
+describe('getEsbuildConfig', () => {
+  test('with sourcemaps returns correct config', () => {
+    const config = getEsbuildConfig({ sourcemap: true }, 'filename.js')
+
+    expect(config).toEqual({
+      format: 'cjs',
+      loader: 'js',
+      target: 'es2018',
+      sourcefile: 'filename.js',
+      sourcemap: true,
+      sourcesContent: false,
+    })
+  })
+
+  describe('with loaders', () => {
+    test('.js loader returns correct config', () => {
+      const config = getEsbuildConfig(
+        { loaders: { '.js': 'jsx' } },
+        'filename.js'
+      )
+
+      expect(config).toEqual({
+        format: 'cjs',
+        loader: 'jsx',
+        target: 'es2018',
+      });
+    });
+
+    xtest('.js loader returns correct config with compound extension', () => {
+      const config = getEsbuildConfig(
+        { loaders: { '.js': 'jsx' } },
+        'filename.test.js'
+      )
+
+      expect(config).toEqual({
+        format: 'cjs',
+        loader: 'jsx',
+        target: 'es2018',
+      });
+    });
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/aelbore/esbuild-jest/issues/52.

The first commit (320216a9c22f2f0d603c01024e52b6181f992f35) refactors the logic for determining the ESBuild config into a separate helper, and introduces some basic tests for it (no behaviour change).

The second commit (93c7f1018d83d268ea4ddda5edf72c573d239316) makes a behaviour change to eliminate the custom `getExt` helper in favour of using `path.extname`.

I'm worried I'm missing the original rationale for the custom helper, so let me know if there is an expected case that this new code doesn't handle!