### PR TITLE
add support for esbuild's 'define' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ export interface Options {
   },
   target?: string
   format?: string
+  define?: { [key: string]: string }
 }
 ```
 

--- a/examples/esbuild-define/index.ts
+++ b/examples/esbuild-define/index.ts
@@ -1,0 +1,1 @@
+export default EXAMPLE_VAR;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ const createTransformer = (options?: Options) => ({
       target: options?.target || 'es2018',
       ...(options?.jsxFactory ? { jsxFactory: options.jsxFactory }: {}),
       ...(options?.jsxFragment ? { jsxFragment: options.jsxFragment }: {}),
+      ...(options?.define ? { define: options.define }: {}),
       ...sourcemaps
     })
   

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,4 +9,5 @@ export interface Options {
   },
   target?: string
   format?: string
+  define?: { [key: string]: string }
 }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -25,6 +25,17 @@ const process = (sourcePath: string, options?: Options) => {
   return { ...output }
 }
 
+test('esbuild transform option', () => {
+    const output = process('./examples/esbuild-define/index.ts', {
+        define: {
+            "EXAMPLE_VAR": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+    })
+
+    expect(output.code).toEqual(expect.stringContaining("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+})
+
+
 test('ts file', () => {
   const names = display()
   expect(names.includes('Jane')).toBeTruthy()


### PR DESCRIPTION
Hi, thanks for the plugin!  Here's a PR that adds support for esbuild's [`define`](https://esbuild.github.io/api/#define) option.

Let me know what you think.  I'm happy to adjust it as needed.