### PR TITLE
fix Babel transform to handle TS type annotations

### DIFF
--- a/examples/names-ts/index.spec.ts
+++ b/examples/names-ts/index.spec.ts
@@ -2,14 +2,14 @@ import { expect } from "@jest/globals"
 
 import { display } from './index'
 
+test('should parse with [jest.mock]', () => {
+  expect(display()).toEqual([ 'Joe' ])  
+})
+
 jest.mock('./index', () => {
   return {
     display() {
       return [ 'Joe' ]
     }
   }
-})
-
-test('should parse with [jest.mock]', () => {
-  expect(display()).toEqual([ 'Joe' ])  
 })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "esbuild": ">=0.9.3"
   },
   "devDependencies": {
-    "@babel/preset-typescript": "^7.13.0",
     "@swc/core": "^1.2.50",
     "@types/jest": "^26.0.21",
     "@types/mock-fs": "^4.13.0",
@@ -51,6 +50,7 @@
   "dependencies": {
     "@babel/core": "^7.13.10",
     "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+    "@babel/preset-typescript": "^7.13.0",
     "babel-jest": "^26.6.3"
   },
   "babel": {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -4,6 +4,7 @@ import { Config } from '@jest/types'
 import babelJest from 'babel-jest'
 
 const { process } = babelJest.createTransformer({
+  presets: [ "@babel/preset-typescript" ],
   plugins: [ "@babel/plugin-transform-modules-commonjs" ],
   parserOpts: { 
     plugins: ["jsx", "typescript"],

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -55,13 +55,13 @@ test('should have sourcemap with [jest.mock]', () => {
       (0, _globals.expect)((0, _index.display)()).toEqual([\\"Joe\\"]);
     });
     
-    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGV4LnNwZWMudHMiXSwibWFwcGluZ3MiOiI7QUFJQSxjQUFLLEtBQUssV0FBVztBQUNuQixTQUFPO0lBQ0w7QUFDRSxhQUFPLENBQUU7Ozs7QUFQZixJQUFBLFdBQUEsUUFBQTtBQUVBLElBQUEsU0FBQSxRQUFBOzs7Ozs7OztBQVVBLEtBQUssaUNBQWlDO0FBQ3BDLEVBQUEsSUFBQSxTQUFBLFFBQU8sSUFBQSxPQUFBLFlBQVcsUUFBUSxDQUFFOzsiLCJuYW1lcyI6W10sInNvdXJjZXNDb250ZW50IjpudWxsfQ=="
+    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGV4LnNwZWMudHMiXSwibWFwcGluZ3MiOiI7QUFRQSxjQUFLLEtBQUssV0FBVyxNQUFNO0FBQ3pCLFNBQU87SUFDTCxVQUFVO0FBQ1IsYUFBTyxDQUFFOzs7O0FBWGYsSUFBQSxXQUFBLFFBQUE7QUFFQSxJQUFBLFNBQUEsUUFBQTs7Ozs7Ozs7QUFFQSxLQUFLLGlDQUFpQyxNQUFNO0FBQzFDLEVBQUEsSUFBQSxTQUFBLFFBQU8sSUFBQSxPQUFBLFlBQVcsUUFBUSxDQUFFOzsiLCJuYW1lcyI6W10sInNvdXJjZXNDb250ZW50IjpudWxsfQ=="
   `)
   
    expect(output.map).toEqual(      {
     version: 3,
     sources: [ 'index.spec.ts' ],
-    mappings: ';AAIA,cAAK,KAAK,WAAW;AACnB,SAAO;IACL;AACE,aAAO,CAAE;;;;AAPf,IAAA,WAAA,QAAA;AAEA,IAAA,SAAA,QAAA;;;;;;;;AAUA,KAAK,iCAAiC;AACpC,EAAA,IAAA,SAAA,QAAO,IAAA,OAAA,YAAW,QAAQ,CAAE;;',
+    mappings: ';AAQA,cAAK,KAAK,WAAW,MAAM;AACzB,SAAO;IACL,UAAU;AACR,aAAO,CAAE;;;;AAXf,IAAA,WAAA,QAAA;AAEA,IAAA,SAAA,QAAA;;;;;;;;AAEA,KAAK,iCAAiC,MAAM;AAC1C,EAAA,IAAA,SAAA,QAAO,IAAA,OAAA,YAAW,QAAQ,CAAE;;',
     names: [],
     sourcesContent: null
   })
@@ -79,13 +79,13 @@ test('should have sourcemap without [jest.mock]', () => {
       display
     };
 
-    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4vZXhhbXBsZXMvbmFtZXMtdHMvaW5kZXgudHMiXSwibWFwcGluZ3MiOiJBQUFBO0FBRU87QUFDTCxTQUFPO0FBQUE7IiwibmFtZXMiOltdLCJzb3VyY2VzQ29udGVudCI6bnVsbH0="
+    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4vZXhhbXBsZXMvbmFtZXMtdHMvaW5kZXgudHMiXSwibWFwcGluZ3MiOiJBQUFBO0FBRU8sbUJBQW1CO0FBQ3hCLFNBQU87QUFBQTsiLCJuYW1lcyI6W10sInNvdXJjZXNDb250ZW50IjpudWxsfQ=="
   `)
 
   expect(output.map).toEqual({
     version: 3,
     sources: [ './examples/names-ts/index.ts' ],
-    mappings: 'AAAA;AAEO;AACL,SAAO;AAAA;',
+    mappings: 'AAAA;AAEO,mBAAmB;AACxB,SAAO;AAAA;',
     names: [],
     sourcesContent: null
   })


### PR DESCRIPTION
The `@babel/plugin-transform-modules-commonjs` transform runs before the esbuild step, which is where TS type annotations are removed.

This can cause files that contain typings to fail with errors like:

```
SyntaxError: xxx.ts: Cannot transform the imported binding "XXX" since it's also used in a type annotation. Please strip type annotations using @babel/preset-typescript or @babel/preset-flow.
```

This commit ensures that files that are transformed via this Babel plugin have their type annotations removed via the `@babel/preset-typescript` preset beforehand.

Fixes #57