### PR TITLE
Add a 'deock' option to prevent fuzzy matching on 'ock(' in source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ export interface Options {
   },
   target?: string
   format?: string
+  deock?: boolean
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const createTransformer = (options?: Options) => ({
     /// this will support the jest.mock
     /// https://github.com/aelbore/esbuild-jest/issues/12
     /// TODO: transform the jest.mock to a function using babel traverse/parse then hoist it
-    if (sources.code.indexOf("ock(") >= 0 || opts?.instrument) {
+    if (!(options?.deock) && (sources.code.indexOf("ock(") >= 0 || opts?.instrument)) {
       const source = require('./transformer').babelTransform({
         sourceText: content,
         sourcePath: filename,

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,4 +9,5 @@ export interface Options {
   },
   target?: string
   format?: string
+  deock?: boolean
 }


### PR DESCRIPTION
This is intended to fix issues like https://github.com/aelbore/esbuild-jest/issues/54
My problem is that I have a class called Block so whenever 'new Block()' appears in a source file esbuild-jest breaks.
